### PR TITLE
Expand the Community Code of Conduct Working Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ This document is inspired and adapated from Codes of Conduct of other communitie
 * [Elastic Community Code of Conduct][elastic]
 
 
-[kevinstock]: https://hackbellingham.slack.com/messages/@kevinstock/
-[nathancarnes]: https://hackbellingham.slack.com/messages/@nathancarnes/
+[kevinstock]: https://bellinghamcodes.slack.com/messages/@kevinstock/
+[nathancarnes]: https://bellinghamcodes.slack.com/messages/@nathancarnes/
 
 [report]: http://goo.gl/forms/1jLQIDF9Ma
 [contributor-covenant]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ With that said, a healthy community must allow for disagreement and debate. The 
 The Community Code of Conduct Working Group is a group of people that are responsible for handling conduct-related issues. Their purpose is to de-escalate conflicts and try to resolve issues to the satisfaction of all parties. They are:
 
 * Kevin Stock ([@kevinstock][kevinstock])
+* Auresa Gaia Nyctea ([@resa][resa])
 * Nathan Carnes ([@nathancarnes][nathancarnes])
 
 
@@ -89,6 +90,7 @@ This document is inspired and adapated from Codes of Conduct of other communitie
 
 
 [kevinstock]: https://bellinghamcodes.slack.com/messages/@kevinstock/
+[resa]: https://bellinghamcodes.slack.com/messages/@resa/
 [nathancarnes]: https://bellinghamcodes.slack.com/messages/@nathancarnes/
 
 [report]: http://goo.gl/forms/1jLQIDF9Ma

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ With that said, a healthy community must allow for disagreement and debate. The 
 The Community Code of Conduct Working Group is a group of people that are responsible for handling conduct-related issues. Their purpose is to de-escalate conflicts and try to resolve issues to the satisfaction of all parties. They are:
 
 * Kevin Stock ([@kevinstock][kevinstock])
+* Nathan Carnes ([@nathancarnes][nathancarnes])
 
 
 ## Handling Issues
@@ -88,6 +89,8 @@ This document is inspired and adapated from Codes of Conduct of other communitie
 
 
 [kevinstock]: https://hackbellingham.slack.com/messages/@kevinstock/
+[nathancarnes]: https://hackbellingham.slack.com/messages/@nathancarnes/
+
 [report]: http://goo.gl/forms/1jLQIDF9Ma
 [contributor-covenant]: http://contributor-covenant.org/version/1/4/
 [go]: https://golang.org/conduct


### PR DESCRIPTION
The Working Group should consist of a group of 4-5 community members to ensure that any issues can be resolved in a timely and appropriate manner. Key considerations in the membership of the group should be:
- Diversity of the Working Group
- Activity of the members
