### PR TITLE
Shorten + simplify CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ We are committed to providing a friendly, safe and welcoming environment for exp
 
 ## Purpose
 
-Diversity is critical strength of our community, but it can also lead to communication issues and unhappiness. The purpose of our Community Code of Conduct is to ensure that all participants have the best possible experience while fostering an open and welcoming environment.
+The purpose of our Community Code of Conduct is to ensure that all participants have the best possible experience, while fostering an open and welcoming environment.
 
-To that end, the gaols of the Community Code of Conduct are to: 
+To that end, the goals of the Community Code of Conduct are to: 
 
 1. Specify a baseline standard of behavior so that people with different social values and communication styles can talk effectively, productively, and respectfully.
 2. Provide a mechanism for resolving conflicts in the community when they arise.
@@ -24,8 +24,7 @@ This Community Code of Conduct applies to:
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to creating a positive environment include:
 
 * Using welcoming and inclusive language
 * Being respectful of differing viewpoints and experiences
@@ -36,14 +35,11 @@ include:
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 This is not an exhaustive list of things that you can or can't do. Rather, take it in the spirit in which it's intended — a guide to make it easier to be excellent to each other. We expect it to be followed in spirit as much as in the letter.
 
@@ -59,17 +55,15 @@ The Community Code of Conduct Working Group is a group of people that are respon
 
 ## Handling Issues
 
-If you encounter a conduct-related issue, you should report it to the Working Group using the process described below. Do not post about the issue publicly or try to rally sentiment against a particular individual or group.
+If you encounter a conduct-related issue, you should report it to the Working Group using the process described below.
 
 1. Submit a [Code of Conduct Report][report]. Your message will reach the Working Group. If you do not feel comfortable contacting the group as a whole you may contact a member of the group directly. That member will then raise the issue with the Working Group as a whole, preserving the privacy of the reporter (if desired).
     * If your report concerns a member of the Working Group they will be recused from Working Group discussions of the report.
     * The Working Group will strive to handle reports with discretion and sensitivity, to protect the privacy of the involved parties, and to avoid conflicts of interest.
 2. The Working Group will meet to review the incident and determine what happened. With the permission of person reporting the incident, the Working Group may reach out to other community members for more context.
 3. The Working Group will reach a decision as to how to act. These may include:
-Nothing.
     * A request for a private or public apology.
     * A private or public warning.
-    * An imposed vacation from community events and spaces.
     * A permanent or temporary ban from some or all community events and spaces.
 4. The Working Group will reach out to the original reporter to let them know the decision.
 5. Appeals to the decision may be made to the Working Group, or to any of its members directly.

--- a/README.md
+++ b/README.md
@@ -2,24 +2,16 @@
 
 We are committed to providing a friendly, safe and welcoming environment for experienced and aspiring technologists, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. 
 
-## Purpose
-
 The purpose of our Community Code of Conduct is to ensure that all participants have the best possible experience, while fostering an open and welcoming environment.
-
-To that end, the goals of the Community Code of Conduct are to: 
-
-1. Specify a baseline standard of behavior so that people with different social values and communication styles can talk effectively, productively, and respectfully.
-2. Provide a mechanism for resolving conflicts in the community when they arise.
-3. Make our community welcoming to people from different backgrounds.
 
 
 ## Scope
 
 This Community Code of Conduct applies to:
 
-1. Community online communication channels. Including, but not limited to: Slack/IRC channels, mailing lists, websites forums, and social media groups.
-2. Community events. Including, but not limited to: meetups and workshops.
-3. Contributions to community open source projects. Including, but not limited to: code, comments, commits, wiki edits, and issues.
+1. Community online communication channel including Slack, mailing lists, and social media groups.
+2. Community events including meetups and workshops.
+3. Contributions to community open source projects including, but not limited to code, comments, commits, wiki edits, and issues.
 
 
 ## Our Standards

--- a/README.md
+++ b/README.md
@@ -41,11 +41,23 @@ The Community Code of Conduct Working Group is a group of people that are respon
 * Kevin Stock ([@kevinstock][kevinstock])
 
 
-## Handling Issues/Enforcement
+## Handling Issues
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by completing a [Code of Conduct Report][report] (this can be done anonymously), or by contacting any of the Community Code of Conduct Working Group members listed above. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The Working Group will maintain confidentiality with regard to the reporter of an incident. 
+If you encounter a conduct-related issue, you should report it to the Working Group using the process described below.
 
-Community Code of Conduct Working Group who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the Community Code of Conduct Working Group.
+1. Submit a [Code of Conduct Report][report]. Your message will reach the Working Group. If you do not feel comfortable contacting the group as a whole you may contact a member of the group directly. That member will then raise the issue with the Working Group as a whole, preserving the privacy of the reporter (if desired).
+    * If your report concerns a member of the Working Group they will be recused from Working Group discussions of the report.
+    * The Working Group will strive to handle reports with discretion and sensitivity, to protect the privacy of the involved parties, and to avoid conflicts of interest.
+2. The Working Group will meet to review the incident and determine what happened. With the permission of person reporting the incident, the Working Group may reach out to other community members for more context.
+3. The Working Group will reach a decision as to how to act. These may include:
+    * A request for a private or public apology.
+    * A private or public warning.
+    * A permanent or temporary ban from some or all community events and spaces.
+4. The Working Group will reach out to the original reporter to let them know the decision.
+5. Appeals to the decision may be made to the Working Group, or to any of its members directly.
+
+Note that the goal of the Code of Conduct and the Working Group is to resolve conflicts in the most harmonious way possible. We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort.
+
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -41,23 +41,11 @@ The Community Code of Conduct Working Group is a group of people that are respon
 * Kevin Stock ([@kevinstock][kevinstock])
 
 
-## Handling Issues
+## Handling Issues/Enforcement
 
-If you encounter a conduct-related issue, you should report it to the Working Group using the process described below.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by completing a [Code of Conduct Report][report] (this can be done anonymously), or by contacting any of the Community Code of Conduct Working Group members listed above. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The Working Group will maintain confidentiality with regard to the reporter of an incident. 
 
-1. Submit a [Code of Conduct Report][report]. Your message will reach the Working Group. If you do not feel comfortable contacting the group as a whole you may contact a member of the group directly. That member will then raise the issue with the Working Group as a whole, preserving the privacy of the reporter (if desired).
-    * If your report concerns a member of the Working Group they will be recused from Working Group discussions of the report.
-    * The Working Group will strive to handle reports with discretion and sensitivity, to protect the privacy of the involved parties, and to avoid conflicts of interest.
-2. The Working Group will meet to review the incident and determine what happened. With the permission of person reporting the incident, the Working Group may reach out to other community members for more context.
-3. The Working Group will reach a decision as to how to act. These may include:
-    * A request for a private or public apology.
-    * A private or public warning.
-    * A permanent or temporary ban from some or all community events and spaces.
-4. The Working Group will reach out to the original reporter to let them know the decision.
-5. Appeals to the decision may be made to the Working Group, or to any of its members directly.
-
-Note that the goal of the Code of Conduct and the Working Group is to resolve conflicts in the most harmonious way possible. We hope that in most cases issues may be resolved through polite discussion and mutual agreement. Bannings and other forceful measures are to be employed only as a last resort.
-
+Community Code of Conduct Working Group who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the Community Code of Conduct Working Group.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@ Examples of unacceptable behavior by participants include:
 * Publishing others' private information, such as a physical or electronic address, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
-This is not an exhaustive list of things that you can or can't do. Rather, take it in the spirit in which it's intended — a guide to make it easier to be excellent to each other. We expect it to be followed in spirit as much as in the letter.
-
-With that said, a healthy community must allow for disagreement and debate. The Code of Conduct is not a mechanism for people to silence others with whom they disagree.
-
 
 ## Community Code of Conduct Working Group
 


### PR DESCRIPTION
This is a much shorter version. My goals were to remove ambiguous language where possible, and remove redundancy. I think I was able to do that without removing any protections.

This is _very_ heavily influenced by the Contributor Covenant v1.4.0.
