### PR TITLE
Proposal to update bellingham.codes Code of Conduct to specifically ban racism, sexism, homophobia, transphobia, and xenophobia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This Community Code of Conduct applies to:
 
 ## Our Standards
 
+No racism, sexism, homophobia, transphobia, or xenophobia.
+
 Examples of behavior that contributes to creating a positive environment include:
 
 * Using welcoming and inclusive language

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Examples of unacceptable behavior by participants include:
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Offensive speech referring to specific groups, whether or not directed at an individual in the community, such as racism, sexism, homophobia, transphobia, or xenophobia
+* Offensive statements referring to specific groups, whether or not directed at an individual in the community, such as racism, sexism, homophobia, transphobia, or xenophobia
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ This Community Code of Conduct applies to:
 
 ## Our Standards
 
-No racism, sexism, homophobia, transphobia, or xenophobia.
-
 Examples of behavior that contributes to creating a positive environment include:
 
 * Using welcoming and inclusive language
@@ -33,6 +31,7 @@ Examples of unacceptable behavior by participants include:
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Offensive speech referring to specific groups, whether or not directed at an individual in the community, such as racism, sexism, homophobia, transphobia, or xenophobia
 * Other conduct which could reasonably be considered inappropriate in a professional setting
 
 


### PR DESCRIPTION
Basically, this steals the first line of the [subdued.social server rules](https://subdued.social/about) (which were in turn borrowed from somewhere else) and adds them as the first line of the "Our Standards" section.

It simply adds the line: "No racism, sexism, homophobia, transphobia, or xenophobia."

IMO a clear statement like this gives the moderation team stronger ground to stand on when dealing with certain kinds of offensive speech that isn't harassment that is specifically directed at another member of our community, yet would still create a chilling, unwelcoming environment to many historically oppressed groups.

I am very much open to suggestions about how a statement like this should be worded and where/how it should be incorporated into the CoC. Consider this PR as the opening of a conversation.

